### PR TITLE
🐛 test suite fixes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -114,7 +114,8 @@ export default class HoprEthereum implements HoprCoreConnector {
      * @param db database instance
      * @param seed that is used to derive that on-chain identity
      * @param options.id Id of the demo account
-     * @param options.uri URI that is used to connect to the blockchain
+     * @param options.provider provider URI that is used to connect to the blockchain
+     * @param options.debug debug mode, will generate account secrets using account's public key
      * @returns a promise resolved to the connector
      */
     static create(db: LevelUp, seed?: Uint8Array, options?: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -308,8 +308,10 @@ let HoprEthereum = /** @class */ (() => {
                     hasOnChainSecret = true;
                 }
                 else {
+                    this.log(`Key is present on-chain but not in our database.`);
                     if (this.options.debug) {
                         await this.db.put(Buffer.from(dbkeys.OnChainSecret()), Buffer.from(this.getDebugAccountSecret()));
+                        hasOffChainSecret = true;
                     }
                     else {
                         throw Error(`Key is present on-chain but not in our database.`);
@@ -367,7 +369,8 @@ let HoprEthereum = /** @class */ (() => {
          * @param db database instance
          * @param seed that is used to derive that on-chain identity
          * @param options.id Id of the demo account
-         * @param options.uri URI that is used to connect to the blockchain
+         * @param options.provider provider URI that is used to connect to the blockchain
+         * @param options.debug debug mode, will generate account secrets using account's public key
          * @returns a promise resolved to the connector
          */
         static async create(db, seed, options) {

--- a/lib/utils/testing.js
+++ b/lib/utils/testing.js
@@ -81,6 +81,8 @@ exports.createAccountAndFund = createAccountAndFund;
  * @returns CoreConnector
  */
 async function createNode(privKey) {
-    return __1.default.create(new levelup_1.default(memdown_1.default()), privKey);
+    return __1.default.create(new levelup_1.default(memdown_1.default()), privKey, {
+        debug: true,
+    });
 }
 exports.createNode = createNode;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@hoprnet/hopr-core-connector-interface": "~1.0.1-0",
     "@hoprnet/hopr-demo-seeds": "~1.0.1",
-    "@hoprnet/hopr-ethereum": "~0.2.0",
+    "@hoprnet/hopr-ethereum": "~0.3.0",
     "@hoprnet/hopr-utils": "~0.1.3",
     "bn.js": "^5.1.1",
     "chalk": "^4.0.0",

--- a/src/dbKeys.spec.ts
+++ b/src/dbKeys.spec.ts
@@ -92,13 +92,18 @@ describe('test dbKeys', function () {
 
   it("should create 'ChannelEntry' key", function () {
     const result = dbKeys.ChannelEntry(userA.address, userB.address)
-    const expected = u8aConcat(encoder.encode('payments-channel-'), userA.address, encoder.encode('-'), userB.address)
+    const expected = u8aConcat(
+      encoder.encode('payments-channelEntry-'),
+      userA.address,
+      encoder.encode('-'),
+      userB.address
+    )
 
     assert(u8aEquals(result, expected), 'check channelEntry key creation')
   })
 
   it("should parse 'ChannelEntry' key", function () {
-    const key = u8aConcat(encoder.encode('payments-channel-'), userA.address, encoder.encode('-'), userB.address)
+    const key = u8aConcat(encoder.encode('payments-channelEntry-'), userA.address, encoder.encode('-'), userB.address)
     const [result1, result2] = dbKeys.ChannelEntryParse(key)
     const expected1 = userA.address
     const expected2 = userB.address

--- a/src/index.ts
+++ b/src/index.ts
@@ -353,8 +353,10 @@ export default class HoprEthereum implements HoprCoreConnector {
         )
         hasOnChainSecret = true
       } else {
+        this.log(`Key is present on-chain but not in our database.`)
         if (this.options.debug) {
           await this.db.put(Buffer.from(dbkeys.OnChainSecret()), Buffer.from(this.getDebugAccountSecret()))
+          hasOffChainSecret = true
         } else {
           throw Error(`Key is present on-chain but not in our database.`)
         }
@@ -423,7 +425,8 @@ export default class HoprEthereum implements HoprCoreConnector {
    * @param db database instance
    * @param seed that is used to derive that on-chain identity
    * @param options.id Id of the demo account
-   * @param options.uri URI that is used to connect to the blockchain
+   * @param options.provider provider URI that is used to connect to the blockchain
+   * @param options.debug debug mode, will generate account secrets using account's public key
    * @returns a promise resolved to the connector
    */
   static async create(

--- a/src/indexer/index.spec.ts
+++ b/src/indexer/index.spec.ts
@@ -15,7 +15,7 @@ import type CoreConnector from '..'
 
 const CLOSURE_DURATION = durations.days(3)
 
-describe.only('test indexer', function () {
+describe('test indexer', function () {
   const ganache = new Ganache()
   let web3: Web3
   let hoprToken: HoprToken

--- a/src/utils/testing.ts
+++ b/src/utils/testing.ts
@@ -91,5 +91,7 @@ export async function createAccountAndFund(
  * @returns CoreConnector
  */
 export async function createNode(privKey: Uint8Array): Promise<CoreConnector> {
-  return CoreConnector.create(new LevelUp(Memdown()), privKey)
+  return CoreConnector.create(new LevelUp(Memdown()), privKey, {
+    debug: true,
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   dependencies:
     micro "^9.3.4"
 
-"@hoprnet/hopr-ethereum@~0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-ethereum/-/hopr-ethereum-0.2.0.tgz#7c454901044b3029df1e8986dfca06717a4fc3c0"
-  integrity sha512-dvWU+qR0Kz4xogirFJRhFc7blH7ivzmKrldOlGnYb2OIwq/ZxrfTa+AARuN7213CqSKgWVN2Axhl3KiMwCyX2A==
+"@hoprnet/hopr-ethereum@~0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-ethereum/-/hopr-ethereum-0.3.0.tgz#8768562913b3af7fecec6c8ac85287a616256f0c"
+  integrity sha512-174c5HhYwfb1NOZ2kqRGW/kRLRYrNMHUWXcdXG+L12+VPvV+w/UIls6DjEeTJSst5CSSmAKyHnYAChhxOfmUVg==
   dependencies:
     "@hoprnet/hopr-demo-seeds" "1.0.1"
     "@hoprnet/hopr-utils" "0.1.3"


### PR DESCRIPTION
A few bugs were introduced in these commits 9fa13c459ddca0aa5fb38e9023737d8ed4875899 and 629b58bd07311e4c41b097b9299e1bdc5f006c49.

- channelEntry prefix was updated, but tests for it were not
- new `hopr-ethereum` package does not ship with `migrations` folder, which is used by tests

this PR fixes:

- update dbkeys tests to use new channelEntry prefix
- improve newly introduced `debug` option documentation
- update `hopr-ethereum` to v0.3.0