### PR TITLE
🐛 fix offChainCounterparty method

### DIFF
--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -186,7 +186,7 @@ class Channel implements IChannel<HoprEthereum> {
   }
 
   get offChainCounterparty(): Promise<Uint8Array> {
-    return this._signedChannel.signer
+    return Promise.resolve(this.counterparty)
   }
 
   get channelId(): Promise<Hash> {


### PR DESCRIPTION
Previously we used the signer to determine who is the off-chain counter party, this doesn't always work since the signer of the channel can be either party A or party B.
Instead we use the known on-chain counterparty since off-chain counterparty and on-chain counterparty are the same.